### PR TITLE
Log objects with whitespace prop names as dictionary value

### DIFF
--- a/src/Destructurama.JsonNet/JsonNet/JsonNetDestructuringPolicy.cs
+++ b/src/Destructurama.JsonNet/JsonNet/JsonNetDestructuringPolicy.cs
@@ -52,7 +52,6 @@ namespace Destructurama.JsonNet
             return new SequenceValue(elems);
         }
 
-
         private static LogEventPropertyValue Destructure(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
         {
             string typeTag = null;

--- a/src/Destructurama.JsonNet/JsonNet/JsonNetDestructuringPolicy.cs
+++ b/src/Destructurama.JsonNet/JsonNet/JsonNetDestructuringPolicy.cs
@@ -20,77 +20,77 @@ using Serilog.Events;
 
 namespace Destructurama.JsonNet
 {
-	internal class JsonNetDestructuringPolicy : IDestructuringPolicy
-	{
-		public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
-		{
-			switch (value)
-			{
-				case JObject jo:
-					result = Destructure(jo, propertyValueFactory);
-					return true;
-				case JArray ja:
-					result = Destructure(ja, propertyValueFactory);
-					return true;
-				case JValue jv:
-					result = Destructure(jv, propertyValueFactory);
-					return true;
-			}
+    internal class JsonNetDestructuringPolicy : IDestructuringPolicy
+    {
+        public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
+        {
+            switch (value)
+            {
+                case JObject jo:
+                    result = Destructure(jo, propertyValueFactory);
+                    return true;
+                case JArray ja:
+                    result = Destructure(ja, propertyValueFactory);
+                    return true;
+                case JValue jv:
+                    result = Destructure(jv, propertyValueFactory);
+                    return true;
+            }
 
-			result = null;
-			return false;
-		}
+            result = null;
+            return false;
+        }
 
-		private static LogEventPropertyValue Destructure(JValue jv, ILogEventPropertyValueFactory propertyValueFactory)
-		{
-			return propertyValueFactory.CreatePropertyValue(jv.Value, true);
-		}
+        private static LogEventPropertyValue Destructure(JValue jv, ILogEventPropertyValueFactory propertyValueFactory)
+        {
+            return propertyValueFactory.CreatePropertyValue(jv.Value, true);
+        }
 
-		private static LogEventPropertyValue Destructure(JArray ja, ILogEventPropertyValueFactory propertyValueFactory)
-		{
-			var elems = ja.Select(t => propertyValueFactory.CreatePropertyValue(t, true));
-			return new SequenceValue(elems);
-		}
+        private static LogEventPropertyValue Destructure(JArray ja, ILogEventPropertyValueFactory propertyValueFactory)
+        {
+            var elems = ja.Select(t => propertyValueFactory.CreatePropertyValue(t, true));
+            return new SequenceValue(elems);
+        }
 
-		private static LogEventPropertyValue Destructure(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
-		{
-			return jo.Properties().All(prop => LogEventProperty.IsValidName(prop.Name)) ?
-				 DestructureToStructureValue(jo, propertyValueFactory) :
-				 DestructureToDictionaryValue(jo, propertyValueFactory);
-		}
+        private static LogEventPropertyValue Destructure(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
+        {
+            return jo.Properties().All(prop => LogEventProperty.IsValidName(prop.Name)) ?
+                 DestructureToStructureValue(jo, propertyValueFactory) :
+                 DestructureToDictionaryValue(jo, propertyValueFactory);
+        }
 
-		private static LogEventPropertyValue DestructureToStructureValue(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
-		{
-			string typeTag = null;
-			var props = new List<LogEventProperty>(jo.Count);
+        private static LogEventPropertyValue DestructureToStructureValue(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
+        {
+            string typeTag = null;
+            var props = new List<LogEventProperty>(jo.Count);
 
-			foreach (var prop in jo.Properties())
-			{
-				if (prop.Name == "$type")
-				{
-					if (prop.Value is JValue typeVal && typeVal.Value is string)
-					{
-						typeTag = (string)typeVal.Value;
-						continue;
-					}
-				}
+            foreach (var prop in jo.Properties())
+            {
+                if (prop.Name == "$type")
+                {
+                    if (prop.Value is JValue typeVal && typeVal.Value is string)
+                    {
+                        typeTag = (string)typeVal.Value;
+                        continue;
+                    }
+                }
 
-				props.Add(new LogEventProperty(prop.Name, propertyValueFactory.CreatePropertyValue(prop.Value, true)));
-			}
+                props.Add(new LogEventProperty(prop.Name, propertyValueFactory.CreatePropertyValue(prop.Value, true)));
+            }
 
-			return new StructureValue(props, typeTag);
-		}
+            return new StructureValue(props, typeTag);
+        }
 
-		private static LogEventPropertyValue DestructureToDictionaryValue(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
-		{
-			var elements = jo.Properties().Select(
-				 prop =>
-					  new KeyValuePair<ScalarValue, LogEventPropertyValue>(
-							new ScalarValue(prop.Name),
-							propertyValueFactory.CreatePropertyValue(prop.Value, true)
-					  )
-			);
-			return new DictionaryValue(elements);
-		}
-	}
+        private static LogEventPropertyValue DestructureToDictionaryValue(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
+        {
+            var elements = jo.Properties().Select(
+                 prop =>
+                      new KeyValuePair<ScalarValue, LogEventPropertyValue>(
+                            new ScalarValue(prop.Name),
+                            propertyValueFactory.CreatePropertyValue(prop.Value, true)
+                      )
+            );
+            return new DictionaryValue(elements);
+        }
+    }
 }

--- a/src/Destructurama.JsonNet/JsonNet/JsonNetDestructuringPolicy.cs
+++ b/src/Destructurama.JsonNet/JsonNet/JsonNetDestructuringPolicy.cs
@@ -52,14 +52,8 @@ namespace Destructurama.JsonNet
             return new SequenceValue(elems);
         }
 
-        private static LogEventPropertyValue Destructure(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
-        {
-            return jo.Properties().All(prop => LogEventProperty.IsValidName(prop.Name)) ?
-                 DestructureToStructureValue(jo, propertyValueFactory) :
-                 DestructureToDictionaryValue(jo, propertyValueFactory);
-        }
 
-        private static LogEventPropertyValue DestructureToStructureValue(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
+        private static LogEventPropertyValue Destructure(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
         {
             string typeTag = null;
             var props = new List<LogEventProperty>(jo.Count);
@@ -74,6 +68,10 @@ namespace Destructurama.JsonNet
                         continue;
                     }
                 }
+                else if (!LogEventProperty.IsValidName(prop.Name))
+                {
+                    return DestructureToDictionaryValue(jo, propertyValueFactory);
+                }
 
                 props.Add(new LogEventProperty(prop.Name, propertyValueFactory.CreatePropertyValue(prop.Value, true)));
             }
@@ -84,11 +82,11 @@ namespace Destructurama.JsonNet
         private static LogEventPropertyValue DestructureToDictionaryValue(JObject jo, ILogEventPropertyValueFactory propertyValueFactory)
         {
             var elements = jo.Properties().Select(
-                 prop =>
-                      new KeyValuePair<ScalarValue, LogEventPropertyValue>(
-                            new ScalarValue(prop.Name),
-                            propertyValueFactory.CreatePropertyValue(prop.Value, true)
-                      )
+                prop =>
+                    new KeyValuePair<ScalarValue, LogEventPropertyValue>(
+                        new ScalarValue(prop.Name),
+                        propertyValueFactory.CreatePropertyValue(prop.Value, true)
+                    )
             );
             return new DictionaryValue(elements);
         }

--- a/test/Destructurama.JsonNet.Tests/JsonNetTypesDestructuringTests.cs
+++ b/test/Destructurama.JsonNet.Tests/JsonNetTypesDestructuringTests.cs
@@ -8,50 +8,52 @@ using Xunit;
 
 namespace Destructurama.JsonNet.Tests
 {
-    class HasName
-    {
-        public string Name { get; set; }
-    }
+	class HasName
+	{
+		public string Name { get; set; }
+	}
 
-    public class JsonNetTypesDestructuringTests
-    {
-        [Fact]
-        public void AttributesAreConsultedWhenDestructuring()
-        {
-            LogEvent evt = null;
+	public class JsonNetTypesDestructuringTests
+	{
+		[Fact]
+		public void AttributesAreConsultedWhenDestructuring()
+		{
+			LogEvent evt = null;
 
-            var log = new LoggerConfiguration()
-                .Destructure.JsonNetTypes()
-                .WriteTo.Sink(new DelegatingSink(e => evt = e))
-                .CreateLogger();
+			var log = new LoggerConfiguration()
+				 .Destructure.JsonNetTypes()
+				 .WriteTo.Sink(new DelegatingSink(e => evt = e))
+				 .CreateLogger();
 
-            var test = new
-            {
-                HN = new HasName { Name = "Some name" },
-                Arr = new[] { 1, 2, 3 },
-                S = "Some string",
-                D = new Dictionary<int, string> { { 1, "One" }, { 2, "Two" } },
-                E = (object)null
-            };
+			var test = new
+			{
+				HN = new HasName { Name = "Some name" },
+				Arr = new[] { 1, 2, 3 },
+				S = "Some string",
+				D = new Dictionary<int, string> { { 1, "One" }, { 2, "Two" } },
+				E = (object)null,
+				ESPN = JsonConvert.DeserializeObject("{\"\":\"Empty string property name\"}"),
+				WSPN = JsonConvert.DeserializeObject("{\"\r\n\":\"Whitespace property name\"}")
+			};
 
-            var ser = JsonConvert.SerializeObject(test, new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.Auto
-            });
-            var dyn = JsonConvert.DeserializeObject<dynamic>(ser);
+			var ser = JsonConvert.SerializeObject(test, new JsonSerializerSettings
+			{
+				TypeNameHandling = TypeNameHandling.Auto
+			});
+			var dyn = JsonConvert.DeserializeObject<dynamic>(ser);
 
-            log.Information("Here is {@Dyn}", dyn);
+			log.Information("Here is {@Dyn}", dyn);
 
-            var sv = (StructureValue)evt.Properties["Dyn"];
-            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+			var sv = (StructureValue)evt.Properties["Dyn"];
+			var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
-            Assert.IsType<StructureValue>(props["HN"]);
-            Assert.IsType<SequenceValue>(props["Arr"]);
-            Assert.IsType<string>(props["S"].LiteralValue());
-            Assert.Null(props["E"].LiteralValue());
-
-            // Not currently handled correctly - will serialize as a structure
-            // Assert.IsInstanceOf<DictionaryValue>(props["D"]);
-        }
-    }
+			Assert.IsType<StructureValue>(props["HN"]);
+			Assert.IsType<SequenceValue>(props["Arr"]);
+			Assert.IsType<string>(props["S"].LiteralValue());
+			Assert.IsType<StructureValue>(props["D"]);
+			Assert.Null(props["E"].LiteralValue());
+			Assert.IsType<DictionaryValue>(props["ESPN"]);
+			Assert.IsType<DictionaryValue>(props["WSPN"]);
+		}
+	}
 }

--- a/test/Destructurama.JsonNet.Tests/JsonNetTypesDestructuringTests.cs
+++ b/test/Destructurama.JsonNet.Tests/JsonNetTypesDestructuringTests.cs
@@ -8,52 +8,52 @@ using Xunit;
 
 namespace Destructurama.JsonNet.Tests
 {
-	class HasName
-	{
-		public string Name { get; set; }
-	}
+    class HasName
+    {
+        public string Name { get; set; }
+    }
 
-	public class JsonNetTypesDestructuringTests
-	{
-		[Fact]
-		public void AttributesAreConsultedWhenDestructuring()
-		{
-			LogEvent evt = null;
+    public class JsonNetTypesDestructuringTests
+    {
+        [Fact]
+        public void AttributesAreConsultedWhenDestructuring()
+        {
+            LogEvent evt = null;
 
-			var log = new LoggerConfiguration()
-				 .Destructure.JsonNetTypes()
-				 .WriteTo.Sink(new DelegatingSink(e => evt = e))
-				 .CreateLogger();
+            var log = new LoggerConfiguration()
+                 .Destructure.JsonNetTypes()
+                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                 .CreateLogger();
 
-			var test = new
-			{
-				HN = new HasName { Name = "Some name" },
-				Arr = new[] { 1, 2, 3 },
-				S = "Some string",
-				D = new Dictionary<int, string> { { 1, "One" }, { 2, "Two" } },
-				E = (object)null,
-				ESPN = JsonConvert.DeserializeObject("{\"\":\"Empty string property name\"}"),
-				WSPN = JsonConvert.DeserializeObject("{\"\r\n\":\"Whitespace property name\"}")
-			};
+            var test = new
+            {
+                HN = new HasName { Name = "Some name" },
+                Arr = new[] { 1, 2, 3 },
+                S = "Some string",
+                D = new Dictionary<int, string> { { 1, "One" }, { 2, "Two" } },
+                E = (object)null,
+                ESPN = JsonConvert.DeserializeObject("{\"\":\"Empty string property name\"}"),
+                WSPN = JsonConvert.DeserializeObject("{\"\r\n\":\"Whitespace property name\"}")
+            };
 
-			var ser = JsonConvert.SerializeObject(test, new JsonSerializerSettings
-			{
-				TypeNameHandling = TypeNameHandling.Auto
-			});
-			var dyn = JsonConvert.DeserializeObject<dynamic>(ser);
+            var ser = JsonConvert.SerializeObject(test, new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Auto
+            });
+            var dyn = JsonConvert.DeserializeObject<dynamic>(ser);
 
-			log.Information("Here is {@Dyn}", dyn);
+            log.Information("Here is {@Dyn}", dyn);
 
-			var sv = (StructureValue)evt.Properties["Dyn"];
-			var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+            var sv = (StructureValue)evt.Properties["Dyn"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
-			Assert.IsType<StructureValue>(props["HN"]);
-			Assert.IsType<SequenceValue>(props["Arr"]);
-			Assert.IsType<string>(props["S"].LiteralValue());
-			Assert.IsType<StructureValue>(props["D"]);
-			Assert.Null(props["E"].LiteralValue());
-			Assert.IsType<DictionaryValue>(props["ESPN"]);
-			Assert.IsType<DictionaryValue>(props["WSPN"]);
-		}
-	}
+            Assert.IsType<StructureValue>(props["HN"]);
+            Assert.IsType<SequenceValue>(props["Arr"]);
+            Assert.IsType<string>(props["S"].LiteralValue());
+            Assert.IsType<StructureValue>(props["D"]);
+            Assert.Null(props["E"].LiteralValue());
+            Assert.IsType<DictionaryValue>(props["ESPN"]);
+            Assert.IsType<DictionaryValue>(props["WSPN"]);
+        }
+    }
 }

--- a/test/Destructurama.JsonNet.Tests/JsonNetTypesDestructuringTests.cs
+++ b/test/Destructurama.JsonNet.Tests/JsonNetTypesDestructuringTests.cs
@@ -21,9 +21,9 @@ namespace Destructurama.JsonNet.Tests
             LogEvent evt = null;
 
             var log = new LoggerConfiguration()
-                 .Destructure.JsonNetTypes()
-                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
-                 .CreateLogger();
+                .Destructure.JsonNetTypes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
 
             var test = new
             {


### PR DESCRIPTION
Change destructuring of `JObject`s from:
- Always destructure to `PropertyValue`
to
- Destructure to `PropertyValue` only if all its prop names pass the `LogEventProperty.IsValidName(<prop_name>)` validation, otherwise destructure to `DictionaryValue`